### PR TITLE
Fix fetching multiple pages of streams API requests

### DIFF
--- a/run.py
+++ b/run.py
@@ -73,7 +73,7 @@ class Twitch:
           }
 
           self.live_streams.append(st)
-        return self.live_streams
+      return self.live_streams
     except IOError:
       return None
 


### PR DESCRIPTION
Due to wrong indentation the loop incorrectly always returned after the first page.
