### PR TITLE
Fix getting channel name from follows response

### DIFF
--- a/run.py
+++ b/run.py
@@ -35,7 +35,7 @@ class Twitch:
           self.data = json.loads(self.f.read())
 
         for channel in self.data['follows']:
-          self.followed_channels.append(channel['channel']['display_name'])
+          self.followed_channels.append(channel['channel']['name'])
       
       return self.followed_channels
     except IOError:


### PR DESCRIPTION
The program currently uses the display name from the follows response on the streams request. Since Twitch introduced custom display names, this is not correct anymore. For example "blizzheroes" has the display name "Heroes of the Storm", the current code tries to use the "Heroes of the Storm" in streams request which fails, because it contains spaces and makes the URL invalid. Using "name" instead fixed this query.
